### PR TITLE
解决在无法获取Client_id，并同时配置了allow_client_ids时发送日志的问题。

### DIFF
--- a/php/SocketLog.class.php
+++ b/php/SocketLog.class.php
@@ -205,6 +205,10 @@ class SocketLog
         $allow_client_ids=self::getConfig('allow_client_ids');
         if(!empty($allow_client_ids))
         {
+            if (!$tabid && in_array(self::getConfig('force_client_id'), $allow_client_ids)) {
+                return true;
+            }
+            
             $client_id=self::getClientArg('client_id');
             if(!in_array($client_id,$allow_client_ids))
             {


### PR DESCRIPTION
如果用户配置了force_client_id，且force_client_id在allow_client_ids中，并同时无法获取当前浏览器的Client_id时，也能返回日志信息。
