### PR TITLE
多个强制推送client_ids支持

### DIFF
--- a/demo.php
+++ b/demo.php
@@ -3,12 +3,19 @@ include './php/slog.function.php';
 
 //配置
 slog(array(
-'host'=>'localhost',//websocket服务器地址，默认localhost
-'optimize'=>false,//是否显示利于优化的参数，如果运行时间，消耗内存等，默认为false
-'show_included_files'=>false,//是否显示本次程序运行加载了哪些文件，默认为false
-'error_handler'=>false,//是否接管程序错误，将程序错误显示在console中，默认为false
-'force_client_id'=>'',//日志强制记录到配置的client_id,默认为空
-'allow_client_ids'=>array()//限制允许读取日志的client_id，默认为空,表示所有人都可以获得日志。
+    'host'                => 'localhost',//websocket服务器地址，默认localhost
+    'optimize'            => false,//是否显示利于优化的参数，如果运行时间，消耗内存等，默认为false
+    'show_included_files' => false,//是否显示本次程序运行加载了哪些文件，默认为false
+    'error_handler'       => false,//是否接管程序错误，将程序错误显示在console中，默认为false
+    'force_client_ids'    => array(//日志强制记录到配置的client_id,默认为空,id必须在allow_client_ids中
+        //'client_01',
+        //'client_02',
+    ), 
+    'allow_client_ids'    => array(//限制允许读取日志的client_id，默认为空,表示所有人都可以获得日志。
+        //'client_01',
+        //'client_02',
+        //'client_03',
+    ), 
 ),'config');
 
 //输出日志

--- a/demo.php
+++ b/demo.php
@@ -7,7 +7,7 @@ slog(array(
     'optimize'            => false,//是否显示利于优化的参数，如果运行时间，消耗内存等，默认为false
     'show_included_files' => false,//是否显示本次程序运行加载了哪些文件，默认为false
     'error_handler'       => false,//是否接管程序错误，将程序错误显示在console中，默认为false
-    'force_client_ids'    => array(//日志强制记录到配置的client_id,默认为空,id必须在allow_client_ids中
+    'force_client_ids'    => array(//日志强制记录到配置的client_id,默认为空,client_id必须在allow_client_ids中
         //'client_01',
         //'client_02',
     ), 


### PR DESCRIPTION
既然`allow_client_ids`支持多个client_id，那`force_client_id`为何不做支持呢？

此次pull request代码正是对此做了修复，望采纳。